### PR TITLE
Fix #15 add include/exclude explaination statements

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,14 +21,19 @@ We support the most recent version of `go`.
 If you need a feature from a newer version listed here changes are welcome.
 
 * [Golang](https://golang.org/dl/) 1.10
-
+* `virtualenv` >= 15.1.*
+* `python` 2.7.*
 
 ### Build
 
 To build the binary for GCSBeat run the command below. This will generate a binary
 in the same directory with the name GCSBeat.
 
-```
+```shell
+# Clean the beat, update the docs and build it
+make clean && make update && make
+
+# Or just build the beat
 make
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,21 +87,9 @@ You can either download GCSBeat compiled binaries or build them yourself.
    You can mock publishing for testing purposes using the `-N` argument.
 4. (Optional) Run `./gcsbeat setup` to install predefined indexes. 
 
-### Requirements
+### Build it Yourself
 
-* [Golang](https://golang.org/dl/) 1.10
-* `virtualenv` >= 15.1.*
-* `python` 2.7.*
-
-### Build
-
-To build the binary for GCSBeat run the command below. This will generate a binary
-in the same directory with the name `gcsbeat`.
-
-```shell
-# Clean the beat, update the docs and build it
-make clean && make update && make
-```
+You can build GCSBeat yourself using the instructions in the `DEVELOPING.md` file.
 
 ### Run
 
@@ -115,6 +103,61 @@ Normal Mode:
 
 ```shell
 ./gcsbeat -c gcsbeat.yml
+```
+
+### Debug
+
+It can sometimes be difficult to figure out why the plugin is or isn't picking up particular files.
+You can enable explain mode by running the beat with the `-d "Explain"` flag:
+
+```shell
+./gcsbeat -d "Explain" -e
+
+```
+
+Here's an example and how to read it:
+
+```
+The bucket gcsbeat-test has five files it can process.
+Note that Cloud Storage lists directories as files.
+INFO	[Explain]	storage/explain.go:55	Source "gs://gcsbeat-test" found 5 files
+DEBUG	[Explain]	storage/explain.go:58	 - "bak-backup-log.log"
+DEBUG	[Explain]	storage/explain.go:58	 - "new.log"
+DEBUG	[Explain]	storage/explain.go:58	 - "old.log"
+DEBUG	[Explain]	storage/explain.go:58	 - "test-folder/"
+DEBUG	[Explain]	storage/explain.go:58	 - "test-folder/test.log"
+
+Two of the files have already been marked as processed using the x-gcsbeat-processed metadata key.
+DEBUG	[Explain]	storage/explain.go:32	Test: has key "x-gcsbeat-processed"?
+DEBUG	[Explain]	storage/explain.go:43	 - "bak-backup-log.log" (pass)
+DEBUG	[Explain]	storage/explain.go:43	 - "new.log" (pass)
+DEBUG	[Explain]	storage/explain.go:46	 - "old.log" (fail)
+DEBUG	[Explain]	storage/explain.go:43	 - "test-folder/" (pass)
+DEBUG	[Explain]	storage/explain.go:46	 - "test-folder/test.log" (fail)
+INFO	[Explain]	storage/explain.go:50	Test: has key "x-gcsbeat-processed"? passed 3 of 5 files
+
+None of the remaining files are already in the pending queue.
+DEBUG	[Explain]	storage/explain.go:32	Test: already pending?
+DEBUG	[Explain]	storage/explain.go:43	 - "bak-backup-log.log" (pass)
+DEBUG	[Explain]	storage/explain.go:43	 - "new.log" (pass)
+DEBUG	[Explain]	storage/explain.go:43	 - "test-folder/" (pass)
+INFO	[Explain]	storage/explain.go:50	Test: already pending? passed 3 of 3 files
+
+Two of the files match the include filter.
+DEBUG	[Explain]	storage/explain.go:32	Test: matches "*.log"?
+DEBUG	[Explain]	storage/explain.go:43	 - "bak-backup-log.log" (pass)
+DEBUG	[Explain]	storage/explain.go:43	 - "new.log" (pass)
+DEBUG	[Explain]	storage/explain.go:46	 - "test-folder/" (fail)
+INFO	[Explain]	storage/explain.go:50	Test: matches "*.log"? passed 2 of 3 files
+
+The backup file matches the exclusion filter so it is skipped.
+DEBUG	[Explain]	storage/explain.go:32	Test: does not match "bak-*"?
+DEBUG	[Explain]	storage/explain.go:46	 - "bak-backup-log.log" (fail)
+DEBUG	[Explain]	storage/explain.go:43	 - "new.log" (pass)
+INFO	[Explain]	storage/explain.go:50	Test: does not match "bak-*"? passed 1 of 2 files
+
+Exactly one file remained.
+INFO	[GCS:gcsone]	beater/gcsbeat.go:131	Added 1 files to queue
 ```
 
 ## License

--- a/beater/storage/afero.go
+++ b/beater/storage/afero.go
@@ -46,14 +46,12 @@ func (asp *aferoStorageProvider) ListUnprocessed() ([]string, error) {
 
 	var out []string
 	for _, f := range files {
-
-		wasProcessed, _ := asp.WasProcessed(f.Name())
-		if !wasProcessed {
-			out = append(out, f.Name())
-		}
+		out = append(out, f.Name())
 	}
 
-	return out, nil
+	explainFoundFiles(asp.fs.Name(), out)
+
+	return FilterAndExplain("exists in processed cache", out, InvertFilter(asp.WasProcessed))
 }
 
 func (asp *aferoStorageProvider) Read(path string) (io.ReadCloser, error) {

--- a/beater/storage/explain.go
+++ b/beater/storage/explain.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type Filter func(filename string) (shouldFilter bool, err error)
+
+var (
+	explainLogger = logp.NewLogger("Explain")
+)
+
+// explainLogger MUST be re-initialized some time after the beat is spun up, otherwise the
+// content is not written to stderr if the user uses that flag.
+func initializeExplainLogger() {
+	explainLogger = logp.NewLogger("Explain")
+}
+
+func FilterAndExplain(filterName string, files []string, filter Filter) (filtered []string, err error) {
+	explainLogger.Debugf("Test: %s?", filterName)
+	var out []string
+	for _, filename := range files {
+
+		shouldFilter, err := filter(filename)
+
+		if err != nil {
+			return out, err
+		}
+
+		if shouldFilter {
+			explainLogger.Debugf(" - %q (pass)", filename)
+			out = append(out, filename)
+		} else {
+			explainLogger.Debugf(" - %q (fail)", filename)
+		}
+	}
+
+	explainLogger.Infof("Test: %s? passed %d of %d files", filterName, len(out), len(files))
+	return out, nil
+}
+
+func explainFoundFiles(source string, files []string) []string {
+	explainLogger.Infof("Source %q found %d files", source, len(files))
+
+	for _, filename := range files {
+		explainLogger.Debugf(" - %q", filename)
+	}
+
+	return files
+}
+
+func InvertFilter(filter Filter) Filter {
+	return func(filename string) (bool, error) {
+		shouldFilter, err := filter(filename)
+		return !shouldFilter, err
+	}
+}

--- a/beater/storage/localprocessed.go
+++ b/beater/storage/localprocessed.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/GoogleCloudPlatform/gcsbeat/config"
@@ -61,7 +62,8 @@ func (middleware *localProcessedMiddleware) ListUnprocessed() ([]string, error) 
 		return nil, err
 	}
 
-	return middleware.removeProcessed(bucketKeys)
+	message := fmt.Sprintf("exists in processed db %q", middleware.db.Path())
+	return FilterAndExplain(message, bucketKeys, InvertFilter(middleware.WasProcessed))
 }
 
 func (middleware *localProcessedMiddleware) Read(path string) (io.ReadCloser, error) {

--- a/beater/storage/storage.go
+++ b/beater/storage/storage.go
@@ -30,6 +30,8 @@ type StorageProvider interface {
 }
 
 func NewStorageProvider(cfg *config.Config) (StorageProvider, error) {
+	initializeExplainLogger()
+
 	provider, err := newBaseStorageProvider(cfg)
 
 	if err != nil {


### PR DESCRIPTION
This PR adds a standard way to explain what's happening in each of the include/exclude steps when files are being filtered from the bucket. This should cut down on the number of questions we're getting around filtering.